### PR TITLE
Gives the user the ability to provide a list_item parameter within th…

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -69,4 +69,6 @@
     <link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
     {{ end }}
 
+    {{ partial "list_item.html" . }}
+
   </head>

--- a/layouts/partials/list_item.html
+++ b/layouts/partials/list_item.html
@@ -1,0 +1,5 @@
+<style>
+  li {
+    list-style-image: url({{.Site.Params.list_item}});
+  }
+</style>

--- a/static/stylesheets/application.css
+++ b/static/stylesheets/application.css
@@ -1,1 +1,1453 @@
-html{box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box}*,:after,:before{box-sizing:inherit;-moz-box-sizing:inherit;-webkit-box-sizing:inherit}html{font-size:62.5%;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;text-size-adjust:none}a,abbr,acronym,address,applet,article,aside,audio,b,big,blockquote,body,canvas,caption,center,cite,code,dd,del,details,dfn,div,dl,dt,em,embed,fieldset,figcaption,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,html,i,iframe,img,ins,kbd,label,legend,li,main,mark,menu,nav,object,ol,output,p,pre,q,ruby,s,samp,section,small,span,strike,strong,sub,summary,sup,table,tbody,td,tfoot,th,thead,time,tr,tt,u,ul,var,video{margin:0;padding:0;border:0}main{display:block}ul{list-style:none}table{border-collapse:collapse;border-spacing:0}td{text-align:left;font-weight:400;vertical-align:middle}button{outline:0;padding:0;background:transparent;border:none;font-size:inherit}input{-webkit-appearance:none;-moz-appearance:none;-ms-appearance:none;-o-appearance:none;appearance:none;outline:none;border:none}a{text-decoration:none;color:inherit}a,button,input,label{-webkit-tap-highlight-color:rgba(255,255,255,0);-webkit-tap-highlight-color:transparent}h1,h2,h3,h4,h5,h6{font-weight:inherit}pre{background:rgba(0,0,0,.05)}pre,pre code{color:rgba(0,0,0,.87)}.c,.c1,.cm,.o{color:rgba(0,0,0,.54)}.k,.kn{color:#a71d5d}.kd,.kt{color:#0086b3}.n.f,.nf{color:#795da3}.nx{color:#0086b3}.s,.s1{color:#183691}.bp,.mi{color:#9575cd}.icon{font-family:Icon;speak:none;font-style:normal;font-weight:400;font-variant:normal;text-transform:none;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.icon-search:before{content:"\e600"}.icon-back:before{content:"\e601"}.icon-link:before{content:"\e602"}.icon-close:before{content:"\e603"}.icon-menu:before{content:"\e604"}.icon-forward:before{content:"\e605"}.icon-twitter:before{content:"\e606"}.icon-github:before{content:"\e607"}.icon-download:before{content:"\e608"}.icon-star:before{content:"\e609"}.icon-warning:before{content:"\e610"}.icon-note:before{content:"\e611"}a{-webkit-transition:color .25s;transition:color .25s}.overlay{-webkit-transition:opacity .25s,width 0s .25s,height 0s .25s;transition:opacity .25s,width 0s .25s,height 0s .25s}#toggle-drawer:checked~.overlay,.toggle-drawer .overlay{-webkit-transition:opacity .25s,width 0s,height 0s;transition:opacity .25s,width 0s,height 0s}.js .header{-webkit-transition:background .6s,color .6s;transition:background .6s,color .6s}.js .header:before{-webkit-transition:background .6s;transition:background .6s}.button .icon{-webkit-transition:background .25s;transition:background .25s}body{color:rgba(0,0,0,.87)}@supports (-webkit-appearance:none){body{background:#e84e40}}.ios body{background:#fff}hr{border:0;border-top:3px solid rgba(0,0,0,.12)}.toggle-button{cursor:pointer;color:inherit}.backdrop,.backdrop-paper:after{background:#fff}.overlay{background:rgba(0,0,0,.54);opacity:0}#toggle-drawer:checked~.overlay,.toggle-drawer .overlay{opacity:1}.header{box-shadow:0 1.5px 3px rgba(0,0,0,.24),0 3px 8px rgba(0,0,0,.05);background:#e84e40;color:#fff}.ios.standalone .header:before{background:rgba(0,0,0,.12)}.bar .path{color:hsla(0,0%,100%,.7)}.button .icon{border-radius:100%}.button .icon:active{background:hsla(0,0%,100%,.12)}html{height:100%}body{position:relative;min-height:100%}hr{display:block;height:1px;padding:0;margin:0}.locked{height:100%;overflow:hidden}.scrollable{position:absolute;top:0;right:0;bottom:0;left:0;overflow:auto;-webkit-overflow-scrolling:touch}.scrollable .wrapper{height:100%}.ios .scrollable .wrapper{margin-bottom:2px}.toggle{display:none}.toggle-button{display:block}.backdrop{position:absolute;top:0;right:0;bottom:0;left:0;z-index:-1}.backdrop-paper{max-width:1200px;height:100%;margin-left:auto;margin-right:auto}.backdrop-paper:after{content:" ";display:block;height:100%;margin-left:262px}.overlay{width:0;height:0;z-index:3}.header,.overlay{position:fixed;top:0}.header{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;left:0;z-index:2;height:56px;padding:4px;overflow:hidden}.ios.standalone .header{position:absolute}.bar{display:table;max-width:1184px;margin-left:auto;margin-right:auto}.bar a{display:block}.no-js .bar .button-search{display:none}.bar .path .icon:before{vertical-align:-1.5px}.button{display:table-cell;vertical-align:top;width:1%}.button button{margin:0;padding:0}.button button:active:before{position:relative;top:0;left:0}.button .icon{display:inline-block;font-size:24px;padding:8px;margin:4px}.stretch{display:table;table-layout:fixed;width:100%}.header .stretch{padding:0 20px}.stretch .title{display:table-cell;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}.header .stretch .title{font-size:18px;padding:13px 0}.main{max-width:1200px;margin-left:auto;margin-right:auto}body,input{font-weight:400;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.no-fontface body,.no-fontface input,body,input{font-family:Helvetica Neue,Helvetica,Arial,sans-serif}.no-fontface code,.no-fontface kbd,.no-fontface pre,code,kbd,pre{font-family:Courier New,Courier,monospace}#toggle-drawer:checked~.main .drawer,.toggle-drawer .drawer{-webkit-transform:translateZ(0);transform:translateZ(0)}.no-csstransforms3d #toggle-drawer:checked~.main .drawer,.no-csstransforms3d .toggle-drawer .drawer{display:block}.project{-webkit-transition:none;transition:none}.project .logo img{-webkit-transition:box-shadow .4s;transition:box-shadow .4s}.repo a{-webkit-transition:box-shadow .4s,opacity .4s;transition:box-shadow .4s,opacity .4s}.drawer .toc a.current,.drawer .toc a:focus,.drawer .toc a:hover{color:#e84e40}.drawer .anchor a{border-left:2px solid #e84e40}.drawer .section{color:rgba(0,0,0,.54)}.ios.standalone .project:before{background:rgba(0,0,0,.12)}.project .logo img{background:#fff;border-radius:100%}.project:focus .logo img,.project:hover .logo img{box-shadow:0 4px 7px rgba(0,0,0,.23),0 8px 25px rgba(0,0,0,.05)}.repo a{background:#00bfa5;color:#fff;border-radius:3px}.repo a:focus,.repo a:hover{box-shadow:0 4px 7px rgba(0,0,0,.23),0 8px 25px rgba(0,0,0,.05);opacity:.8}.repo a .count{background:rgba(0,0,0,.26);color:#fff;border-radius:0 3px 3px 0}.repo a .count:before{border-width:15px 5px 15px 0;border-color:transparent rgba(0,0,0,.26);border-style:solid}.drawer{width:262px;font-size:13px;line-height:1em}.ios .drawer{overflow:scroll;-webkit-overflow-scrolling:touch}.drawer .toc li a{display:block;padding:14.5px 24px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.drawer .toc li.anchor a{margin-left:12px;padding:10px 24px 10px 12px}.drawer .toc li ul{margin-left:12px}.drawer .current+ul{margin-bottom:9px}.drawer .section{display:block;padding:14.5px 24px}.drawer .scrollable{top:104px;z-index:-1}.drawer .scrollable .wrapper{height:auto;min-height:100%}.drawer .scrollable .wrapper hr{margin:12px 0;margin-right:auto}.drawer .scrollable .wrapper .toc{margin:12px 0}.project{display:block}.project .banner{display:table;width:100%;height:104px;padding:20px}.project .logo{display:table-cell;width:64px;padding-right:12px}.project .logo img{display:block;width:64px;height:64px}.project .name{display:table-cell;padding-left:4px;font-size:14px;line-height:1.25em;vertical-align:middle}.project .logo+.name{font-size:12px}.repo{margin:24px 0;text-align:center}.repo li{display:inline-block;padding-right:12px;white-space:nowrap}.repo li:last-child{padding-right:0}.repo a{display:inline-block;padding:0 10px 0 6px;font-size:12px;line-height:30px;height:30px}.repo a .icon{font-size:18px;vertical-align:-3px}.repo a .count{display:inline-block;position:relative;padding:0 8px 0 4px;margin:0 -10px 0 8px;font-size:12px}.repo a .count:before{content:" ";display:block;position:absolute;top:0;left:-5px}.no-js .repo a .count{display:none}.drawer .toc li a{font-weight:700}.drawer .toc li.anchor a{font-weight:400}.drawer .section,.repo a{font-weight:700}.repo a{text-transform:uppercase}.repo a .count{text-transform:none;font-weight:700}pre span{-webkit-transition:color .25s;transition:color .25s}.copyright a{-webkit-transition:color .25s;transition:color .25s}.ios.standalone .article{background:-webkit-linear-gradient(top,#fff 50%,#e84e40 0);background:linear-gradient(180deg,#fff 50%,#e84e40 0)}.ios.standalone .article .wrapper{background:-webkit-linear-gradient(top,#fff 50%,#fff 0);background:linear-gradient(180deg,#fff 50%,#fff 0)}.article a,.article h1,.article h2{color:#e84e40}.article code{background:#eee}.article kbd{color:#555;background-color:#fcfcfc;border:1px solid #ccc;border-bottom-color:#bbb;border-radius:3px;box-shadow:inset 0 -1px 0 #bbb}.article h1{border-bottom:1px solid rgba(0,0,0,.12)}.article a{border-bottom:1px dotted}.article a:focus,.article a:hover{color:#00bfa5}.article .headerlink{color:rgba(0,0,0,.26);border:none}.article table{box-shadow:0 1.5px 3px rgba(0,0,0,.24),0 3px 8px rgba(0,0,0,.05);border-radius:3px}.article table th{background:#ee7a70;color:#fff}.article table td{border-top:1px solid rgba(0,0,0,.05)}.article blockquote{border-left:2px solid rgba(0,0,0,.54);color:rgba(0,0,0,.54)}.footer{background:#e84e40;color:#fff}.footer a{border:none}.copyright{color:rgba(0,0,0,.54)}.pagination a .button,.pagination a .title{color:#fff}.pagination .direction{color:hsla(0,0%,100%,.7)}.admonition{background:#29b6f6;color:#fff}.admonition pre{background:hsla(0,0%,100%,.3)}.admonition.warning{background:#e84e40}.admonition a,.admonition a:hover{color:#fff}.article{font-size:14px;line-height:1.7em}.article:after{content:" ";display:block;clear:both}.article .wrapper{padding:80px 16px 92px}.ios.standalone .article{position:absolute;top:56px;right:0;bottom:0;left:0;overflow:auto;-webkit-overflow-scrolling:touch}.ios.standalone .article .wrapper{position:relative;min-height:100%;padding-top:60px;margin-bottom:2px}.article h1{font-size:24px;line-height:1.333334em;padding:8px 0 16px}.article h2{font-size:20px;line-height:1.4em;padding-top:92px;margin-top:-56px}.ios.standalone .article h2{padding-top:36px;margin:0}.article h3,.article h4{font-size:14px;padding-top:76px;margin-top:-56px}.ios.standalone .article h3,.ios.standalone .article h4{padding-top:20px;margin-top:0}.article .headerlink{float:right;margin-left:20px;font-size:14px}h1 .article .headerlink{display:none}.article ol,.article p,.article ul{margin-top:1.5em}.article li,.article li ol,.article li ul{margin-top:.75em}.article li{margin-left:18px}.article li p{display:inline}.article ul>li:before{content:"\f013";display:block;float:left;font-family:FontAwesome;font-size:16px;width:1.2em;margin-left:-1.2em;vertical-align:-.1em}.article p>code{white-space:nowrap;padding:2px 4px}.article kbd{display:inline-block;padding:3px 5px;line-height:10px}.article hr{margin-top:1.5em}.article img{max-width:100%}.article pre{padding:16px;margin:1.5em -16px 0;line-height:1.5em;overflow:auto;-webkit-overflow-scrolling:touch}.article table{margin:3em 0 1.5em;font-size:13px;overflow:hidden}.no-js .article table{display:inline-block;max-width:100%;overflow:auto;-webkit-overflow-scrolling:touch}.article table th{min-width:100px;font-size:12px;text-align:left}.article table td,.article table th{padding:12px 16px;vertical-align:top}.article blockquote{padding-left:16px}.article .data{margin:1.5em -16px;padding:1.5em 0;overflow:auto;-webkit-overflow-scrolling:touch;text-align:center}.article .data table{display:inline-block;margin:0 16px;text-align:left}.footer{position:absolute;bottom:0;left:0;right:0;padding:0 4px}.copyright{margin:1.5em 0}.pagination{max-width:1184px;height:92px;padding:4px 0;margin-left:auto;margin-right:auto;overflow:hidden}.pagination a{display:block;height:100%}.pagination .next,.pagination .previous{position:relative;float:left;height:100%}.pagination .previous{width:25%}.pagination .previous .direction,.pagination .previous .stretch{display:none}.pagination .next{width:75%;text-align:right}.pagination .page{display:table;position:absolute;bottom:4px}.pagination .direction{display:block;position:absolute;bottom:40px;width:100%;font-size:15px;line-height:20px;padding:0 52px}.pagination .stretch{padding:0 4px}.pagination .stretch .title{font-size:18px;padding:11px 0 13px}.admonition{margin:20px -16px 0;padding:20px 16px}.admonition>:first-child{margin-top:0}.admonition .admonition-title{font-size:20px}.admonition .admonition-title:before{content:"\e611";display:block;float:left;font-family:Icon;font-size:24px;vertical-align:-.1em;margin-right:5px}.admonition.warning .admonition-title:before{content:"\e610"}.article h3{font-weight:700}.article h4{font-weight:400;font-style:italic}.article h2 a,.article h3 a,.article h4 a,.article h5 a,.article h6 a{font-weight:400;font-style:normal}.bar{-webkit-transform:translateZ(0);transform:translateZ(0);-webkit-transition:opacity .2s cubic-bezier(.75,0,.25,1),-webkit-transform .4s cubic-bezier(.75,0,.25,1);transition:opacity .2s cubic-bezier(.75,0,.25,1),-webkit-transform .4s cubic-bezier(.75,0,.25,1);transition:opacity .2s cubic-bezier(.75,0,.25,1),transform .4s cubic-bezier(.75,0,.25,1);transition:opacity .2s cubic-bezier(.75,0,.25,1),transform .4s cubic-bezier(.75,0,.25,1),-webkit-transform .4s cubic-bezier(.75,0,.25,1)}#toggle-search:checked~.header .bar,.toggle-search .bar{-webkit-transform:translate3d(0,-56px,0);transform:translate3d(0,-56px,0)}.bar.search .button-reset{-webkit-transform:scale(.5);transform:scale(.5);-webkit-transition:opacity .4s cubic-bezier(.1,.7,.1,1),-webkit-transform .4s cubic-bezier(.1,.7,.1,1);transition:opacity .4s cubic-bezier(.1,.7,.1,1),-webkit-transform .4s cubic-bezier(.1,.7,.1,1);transition:opacity .4s cubic-bezier(.1,.7,.1,1),transform .4s cubic-bezier(.1,.7,.1,1);transition:opacity .4s cubic-bezier(.1,.7,.1,1),transform .4s cubic-bezier(.1,.7,.1,1),-webkit-transform .4s cubic-bezier(.1,.7,.1,1);opacity:0}.bar.search.non-empty .button-reset{-webkit-transform:scale(1);transform:scale(1);opacity:1}.results{-webkit-transition:opacity .3s .1s,width 0s .4s,height 0s .4s;transition:opacity .3s .1s,width 0s .4s,height 0s .4s}#toggle-search:checked~.main .results,.toggle-search .results{-webkit-transition:opacity .4s,width 0s,height 0s;transition:opacity .4s,width 0s,height 0s}.results .list a{-webkit-transition:background .25s;transition:background .25s}.no-csstransforms3d .bar.default{display:table}.no-csstransforms3d .bar.search{display:none;margin-top:0}.no-csstransforms3d #toggle-search:checked~.header .bar.default,.no-csstransforms3d .toggle-search .bar.default{display:none}.no-csstransforms3d #toggle-search:checked~.header .bar.search,.no-csstransforms3d .toggle-search .bar.search{display:table}.bar.search{opacity:0}.bar.search .query{background:transparent;color:rgba(0,0,0,.87)}.bar.search .query::-webkit-input-placeholder{color:rgba(0,0,0,.26)}.bar.search .query:-moz-placeholder,.bar.search .query::-moz-placeholder{color:rgba(0,0,0,.26)}.bar.search .query:-ms-input-placeholder{color:rgba(0,0,0,.26)}.bar.search .button .icon:active{background:rgba(0,0,0,.12)}.results{box-shadow:0 4px 7px rgba(0,0,0,.23),0 8px 25px rgba(0,0,0,.05);background:#fff;color:rgba(0,0,0,.87);opacity:0}#toggle-search:checked~.main .results,.toggle-search .results{opacity:1}.results .meta{background:#e84e40;color:#fff}.results .list a{border-bottom:1px solid rgba(0,0,0,.12)}.results .list a:last-child{border-bottom:none}.results .list a:active{background:rgba(0,0,0,.12)}.result span{color:rgba(0,0,0,.54)}#toggle-search:checked~.header,.toggle-search .header{background:#fff;color:rgba(0,0,0,.54)}#toggle-search:checked~.header:before,.toggle-search .header:before{background:rgba(0,0,0,.54)}#toggle-search:checked~.header .bar.default,.toggle-search .header .bar.default{opacity:0}#toggle-search:checked~.header .bar.search,.toggle-search .header .bar.search{opacity:1}.bar.search{margin-top:8px}.bar.search .query{font-size:18px;padding:13px 0;margin:0;width:100%;height:48px}.bar.search .query::-ms-clear{display:none}.results{position:fixed;top:0;left:0;width:0;height:100%;z-index:1;overflow-y:scroll;-webkit-overflow-scrolling:touch}.results .scrollable{top:56px}#toggle-search:checked~.main .results,.toggle-search .results{width:100%;overflow-y:visible}.results .meta{font-weight:700}.results .meta strong{display:block;font-size:11px;max-width:1200px;margin-left:auto;margin-right:auto;padding:16px}.results .list a{display:block}.result{max-width:1200px;margin-left:auto;margin-right:auto;padding:12px 16px 16px}.result h1{line-height:24px}.result h1,.result span{text-overflow:ellipsis;white-space:nowrap;overflow:hidden}.result span{font-size:12px}.no-csstransforms3d .results{display:none}.no-csstransforms3d #toggle-search:checked~.main .results,.no-csstransforms3d .toggle-search .results{display:block;overflow:auto}.meta{text-transform:uppercase;font-weight:700}@media only screen and (min-width:960px){.backdrop{background:#f2f2f2}.backdrop-paper:after{box-shadow:0 1.5px 3px rgba(0,0,0,.24),0 3px 8px rgba(0,0,0,.05)}.button-menu{display:none}.drawer{float:left;height:auto;margin-bottom:96px;padding-top:80px}.drawer,.drawer .scrollable{position:static}.article{margin-left:262px}.footer{z-index:4}.copyright{margin-bottom:64px}.results{height:auto;top:64px}.results .scrollable{position:static;max-height:413px}}@media only screen and (max-width:959px){#toggle-drawer:checked~.overlay,.toggle-drawer .overlay{width:100%;height:100%}.drawer{-webkit-transform:translate3d(-262px,0,0);transform:translate3d(-262px,0,0);-webkit-transition:-webkit-transform .25s cubic-bezier(.4,0,.2,1);transition:-webkit-transform .25s cubic-bezier(.4,0,.2,1);transition:transform .25s cubic-bezier(.4,0,.2,1);transition:transform .25s cubic-bezier(.4,0,.2,1),-webkit-transform .25s cubic-bezier(.4,0,.2,1)}.no-csstransforms3d .drawer{display:none}.drawer{background:#fff}.project{box-shadow:0 1.5px 3px rgba(0,0,0,.24),0 3px 8px rgba(0,0,0,.05);background:#e84e40;color:#fff}.drawer{position:fixed;z-index:4}#toggle-search:checked~.main .results,.drawer,.toggle-search .results{height:100%}}@media only screen and (min-width:720px){.header{height:64px;padding:8px}.header .stretch{padding:0 16px}.header .stretch .title{font-size:20px;padding:12px 0}.project .name{margin:26px 0 0 5px}.article .wrapper{padding:90px 24px 96px}.article .data{margin:1.5em -24px}.article .data table{margin:0 24px}.article h2{padding-top:100px;margin-top:-64px}.ios.standalone .article h2{padding-top:28px;margin-top:8px}.article h3,.article h4{padding-top:84px;margin-top:-64px}.ios.standalone .article h3,.ios.standalone .article h4{padding-top:20px;margin-top:0}.article pre{padding:1.5em 24px;margin:1.5em -24px 0}.footer{padding:0 8px}.pagination{height:96px;padding:8px 0}.pagination .direction{padding:0 56px;bottom:40px}.pagination .stretch{padding:0 8px}.admonition{margin:20px -24px 0;padding:20px 24px}.bar.search .query{font-size:20px;padding:12px 0}.results .scrollable{top:64px}.results .meta strong{padding:16px 24px}.result{padding:16px 24px 20px}}@media only screen and (min-width:1200px){.header{width:100%}.drawer .scrollable .wrapper hr{width:48px}}@media only screen and (orientation:portrait){.ios.standalone .header{height:76px;padding-top:24px}.ios.standalone .header:before{content:" ";position:absolute;top:0;left:0;z-index:3;width:100%;height:20px}.ios.standalone .drawer .scrollable{top:124px}.ios.standalone .project{padding-top:20px}.ios.standalone .project:before{content:" ";position:absolute;top:0;left:0;z-index:3;width:100%;height:20px}.ios.standalone .article{position:absolute;top:76px;right:0;bottom:0;left:0}.ios.standalone .results .scrollable{top:76px}}@media only screen and (orientation:portrait) and (min-width:720px){.ios.standalone .header{height:84px;padding-top:28px}.ios.standalone .results .scrollable{top:84px}}@media only screen and (max-width:719px){.bar .path{display:none}}@media only screen and (max-width:479px){.button-github,.button-twitter{display:none}}@media only screen and (min-width:720px) and (max-width:959px){.header .stretch{padding:0 24px}}@media only screen and (min-width:480px){.pagination .next,.pagination .previous{width:50%}.pagination .previous .direction{display:block}.pagination .previous .stretch{display:table}}@media print{.drawer,.footer,.header,.headerlink{display:none}.article .wrapper{padding-top:0}.article pre,.article pre *{color:rgba(0,0,0,.87)!important}.article pre{border:1px solid rgba(0,0,0,.12)}.article table{border-radius:none;box-shadow:none}.article table th{color:#e84e40}}
+html {
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+*,
+:after,
+:before {
+  box-sizing: inherit;
+  -moz-box-sizing: inherit;
+  -webkit-box-sizing: inherit;
+}
+html {
+  font-size: 62.5%;
+  -webkit-text-size-adjust: none;
+  -ms-text-size-adjust: none;
+  text-size-adjust: none;
+}
+a,
+abbr,
+acronym,
+address,
+applet,
+article,
+aside,
+audio,
+b,
+big,
+blockquote,
+body,
+canvas,
+caption,
+center,
+cite,
+code,
+dd,
+del,
+details,
+dfn,
+div,
+dl,
+dt,
+em,
+embed,
+fieldset,
+figcaption,
+figure,
+footer,
+form,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+header,
+hgroup,
+html,
+i,
+iframe,
+img,
+ins,
+kbd,
+label,
+legend,
+li,
+main,
+mark,
+menu,
+nav,
+object,
+ol,
+output,
+p,
+pre,
+q,
+ruby,
+s,
+samp,
+section,
+small,
+span,
+strike,
+strong,
+sub,
+summary,
+sup,
+table,
+tbody,
+td,
+tfoot,
+th,
+thead,
+time,
+tr,
+tt,
+u,
+ul,
+var,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+main {
+  display: block;
+}
+ul {
+  list-style: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+td {
+  text-align: left;
+  font-weight: 400;
+  vertical-align: middle;
+}
+button {
+  outline: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
+  font-size: inherit;
+}
+input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  -o-appearance: none;
+  appearance: none;
+  outline: none;
+  border: none;
+}
+a {
+  text-decoration: none;
+  color: inherit;
+}
+a,
+button,
+input,
+label {
+  -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  -webkit-tap-highlight-color: transparent;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: inherit;
+}
+pre {
+  background: rgba(0, 0, 0, 0.05);
+}
+pre,
+pre code {
+  color: rgba(0, 0, 0, 0.87);
+}
+.c,
+.c1,
+.cm,
+.o {
+  color: rgba(0, 0, 0, 0.54);
+}
+.k,
+.kn {
+  color: #a71d5d;
+}
+.kd,
+.kt {
+  color: #0086b3;
+}
+.n.f,
+.nf {
+  color: #795da3;
+}
+.nx {
+  color: #0086b3;
+}
+.s,
+.s1 {
+  color: #183691;
+}
+.bp,
+.mi {
+  color: #9575cd;
+}
+.icon {
+  font-family: Icon;
+  speak: none;
+  font-style: normal;
+  font-weight: 400;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.icon-search:before {
+  content: '\e600';
+}
+.icon-back:before {
+  content: '\e601';
+}
+.icon-link:before {
+  content: '\e602';
+}
+.icon-close:before {
+  content: '\e603';
+}
+.icon-menu:before {
+  content: '\e604';
+}
+.icon-forward:before {
+  content: '\e605';
+}
+.icon-twitter:before {
+  content: '\e606';
+}
+.icon-github:before {
+  content: '\e607';
+}
+.icon-download:before {
+  content: '\e608';
+}
+.icon-star:before {
+  content: '\e609';
+}
+.icon-warning:before {
+  content: '\e610';
+}
+.icon-note:before {
+  content: '\e611';
+}
+a {
+  -webkit-transition: color 0.25s;
+  transition: color 0.25s;
+}
+.overlay {
+  -webkit-transition: opacity 0.25s, width 0s 0.25s, height 0s 0.25s;
+  transition: opacity 0.25s, width 0s 0.25s, height 0s 0.25s;
+}
+#toggle-drawer:checked ~ .overlay,
+.toggle-drawer .overlay {
+  -webkit-transition: opacity 0.25s, width 0s, height 0s;
+  transition: opacity 0.25s, width 0s, height 0s;
+}
+.js .header {
+  -webkit-transition: background 0.6s, color 0.6s;
+  transition: background 0.6s, color 0.6s;
+}
+.js .header:before {
+  -webkit-transition: background 0.6s;
+  transition: background 0.6s;
+}
+.button .icon {
+  -webkit-transition: background 0.25s;
+  transition: background 0.25s;
+}
+body {
+  color: rgba(0, 0, 0, 0.87);
+}
+@supports (-webkit-appearance: none) {
+  body {
+    background: #e84e40;
+  }
+}
+.ios body {
+  background: #fff;
+}
+hr {
+  border: 0;
+  border-top: 3px solid rgba(0, 0, 0, 0.12);
+}
+.toggle-button {
+  cursor: pointer;
+  color: inherit;
+}
+.backdrop,
+.backdrop-paper:after {
+  background: #fff;
+}
+.overlay {
+  background: rgba(0, 0, 0, 0.54);
+  opacity: 0;
+}
+#toggle-drawer:checked ~ .overlay,
+.toggle-drawer .overlay {
+  opacity: 1;
+}
+.header {
+  box-shadow: 0 1.5px 3px rgba(0, 0, 0, 0.24), 0 3px 8px rgba(0, 0, 0, 0.05);
+  background: #e84e40;
+  color: #fff;
+}
+.ios.standalone .header:before {
+  background: rgba(0, 0, 0, 0.12);
+}
+.bar .path {
+  color: hsla(0, 0%, 100%, 0.7);
+}
+.button .icon {
+  border-radius: 100%;
+}
+.button .icon:active {
+  background: hsla(0, 0%, 100%, 0.12);
+}
+html {
+  height: 100%;
+}
+body {
+  position: relative;
+  min-height: 100%;
+}
+hr {
+  display: block;
+  height: 1px;
+  padding: 0;
+  margin: 0;
+}
+.locked {
+  height: 100%;
+  overflow: hidden;
+}
+.scrollable {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.scrollable .wrapper {
+  height: 100%;
+}
+.ios .scrollable .wrapper {
+  margin-bottom: 2px;
+}
+.toggle {
+  display: none;
+}
+.toggle-button {
+  display: block;
+}
+.backdrop {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: -1;
+}
+.backdrop-paper {
+  max-width: 1200px;
+  height: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+.backdrop-paper:after {
+  content: ' ';
+  display: block;
+  height: 100%;
+  margin-left: 262px;
+}
+.overlay {
+  width: 0;
+  height: 0;
+  z-index: 3;
+}
+.header,
+.overlay {
+  position: fixed;
+  top: 0;
+}
+.header {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  left: 0;
+  z-index: 2;
+  height: 56px;
+  padding: 4px;
+  overflow: hidden;
+}
+.ios.standalone .header {
+  position: absolute;
+}
+.bar {
+  display: table;
+  max-width: 1184px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.bar a {
+  display: block;
+}
+.no-js .bar .button-search {
+  display: none;
+}
+.bar .path .icon:before {
+  vertical-align: -1.5px;
+}
+.button {
+  display: table-cell;
+  vertical-align: top;
+  width: 1%;
+}
+.button button {
+  margin: 0;
+  padding: 0;
+}
+.button button:active:before {
+  position: relative;
+  top: 0;
+  left: 0;
+}
+.button .icon {
+  display: inline-block;
+  font-size: 24px;
+  padding: 8px;
+  margin: 4px;
+}
+.stretch {
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+}
+.header .stretch {
+  padding: 0 20px;
+}
+.stretch .title {
+  display: table-cell;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.header .stretch .title {
+  font-size: 18px;
+  padding: 13px 0;
+}
+.main {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+}
+body,
+input {
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.no-fontface body,
+.no-fontface input,
+body,
+input {
+  font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+}
+.no-fontface code,
+.no-fontface kbd,
+.no-fontface pre,
+code,
+kbd,
+pre {
+  font-family: Courier New, Courier, monospace;
+}
+#toggle-drawer:checked ~ .main .drawer,
+.toggle-drawer .drawer {
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+}
+.no-csstransforms3d #toggle-drawer:checked ~ .main .drawer,
+.no-csstransforms3d .toggle-drawer .drawer {
+  display: block;
+}
+.project {
+  -webkit-transition: none;
+  transition: none;
+}
+.project .logo img {
+  -webkit-transition: box-shadow 0.4s;
+  transition: box-shadow 0.4s;
+}
+.repo a {
+  -webkit-transition: box-shadow 0.4s, opacity 0.4s;
+  transition: box-shadow 0.4s, opacity 0.4s;
+}
+.drawer .toc a.current,
+.drawer .toc a:focus,
+.drawer .toc a:hover {
+  color: #e84e40;
+}
+.drawer .anchor a {
+  border-left: 2px solid #e84e40;
+}
+.drawer .section {
+  color: rgba(0, 0, 0, 0.54);
+}
+.ios.standalone .project:before {
+  background: rgba(0, 0, 0, 0.12);
+}
+.project .logo img {
+  background: #fff;
+  border-radius: 100%;
+}
+.project:focus .logo img,
+.project:hover .logo img {
+  box-shadow: 0 4px 7px rgba(0, 0, 0, 0.23), 0 8px 25px rgba(0, 0, 0, 0.05);
+}
+.repo a {
+  background: #00bfa5;
+  color: #fff;
+  border-radius: 3px;
+}
+.repo a:focus,
+.repo a:hover {
+  box-shadow: 0 4px 7px rgba(0, 0, 0, 0.23), 0 8px 25px rgba(0, 0, 0, 0.05);
+  opacity: 0.8;
+}
+.repo a .count {
+  background: rgba(0, 0, 0, 0.26);
+  color: #fff;
+  border-radius: 0 3px 3px 0;
+}
+.repo a .count:before {
+  border-width: 15px 5px 15px 0;
+  border-color: transparent rgba(0, 0, 0, 0.26);
+  border-style: solid;
+}
+.drawer {
+  width: 262px;
+  font-size: 13px;
+  line-height: 1em;
+}
+.ios .drawer {
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
+}
+.drawer .toc li a {
+  display: block;
+  padding: 14.5px 24px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.drawer .toc li.anchor a {
+  margin-left: 12px;
+  padding: 10px 24px 10px 12px;
+}
+.drawer .toc li ul {
+  margin-left: 12px;
+}
+.drawer .current + ul {
+  margin-bottom: 9px;
+}
+.drawer .section {
+  display: block;
+  padding: 14.5px 24px;
+}
+.drawer .scrollable {
+  top: 104px;
+  z-index: -1;
+}
+.drawer .scrollable .wrapper {
+  height: auto;
+  min-height: 100%;
+}
+.drawer .scrollable .wrapper hr {
+  margin: 12px 0;
+  margin-right: auto;
+}
+.drawer .scrollable .wrapper .toc {
+  margin: 12px 0;
+}
+.project {
+  display: block;
+}
+.project .banner {
+  display: table;
+  width: 100%;
+  height: 104px;
+  padding: 20px;
+}
+.project .logo {
+  display: table-cell;
+  width: 64px;
+  padding-right: 12px;
+}
+.project .logo img {
+  display: block;
+  width: 64px;
+  height: 64px;
+}
+.project .name {
+  display: table-cell;
+  padding-left: 4px;
+  font-size: 14px;
+  line-height: 1.25em;
+  vertical-align: middle;
+}
+.project .logo + .name {
+  font-size: 12px;
+}
+.repo {
+  margin: 24px 0;
+  text-align: center;
+}
+.repo li {
+  display: inline-block;
+  padding-right: 12px;
+  white-space: nowrap;
+}
+.repo li:last-child {
+  padding-right: 0;
+}
+.repo a {
+  display: inline-block;
+  padding: 0 10px 0 6px;
+  font-size: 12px;
+  line-height: 30px;
+  height: 30px;
+}
+.repo a .icon {
+  font-size: 18px;
+  vertical-align: -3px;
+}
+.repo a .count {
+  display: inline-block;
+  position: relative;
+  padding: 0 8px 0 4px;
+  margin: 0 -10px 0 8px;
+  font-size: 12px;
+}
+.repo a .count:before {
+  content: ' ';
+  display: block;
+  position: absolute;
+  top: 0;
+  left: -5px;
+}
+.no-js .repo a .count {
+  display: none;
+}
+.drawer .toc li a {
+  font-weight: 700;
+}
+.drawer .toc li.anchor a {
+  font-weight: 400;
+}
+.drawer .section,
+.repo a {
+  font-weight: 700;
+}
+.repo a {
+  text-transform: uppercase;
+}
+.repo a .count {
+  text-transform: none;
+  font-weight: 700;
+}
+pre span {
+  -webkit-transition: color 0.25s;
+  transition: color 0.25s;
+}
+.copyright a {
+  -webkit-transition: color 0.25s;
+  transition: color 0.25s;
+}
+.ios.standalone .article {
+  background: -webkit-linear-gradient(top, #fff 50%, #e84e40 0);
+  background: linear-gradient(180deg, #fff 50%, #e84e40 0);
+}
+.ios.standalone .article .wrapper {
+  background: -webkit-linear-gradient(top, #fff 50%, #fff 0);
+  background: linear-gradient(180deg, #fff 50%, #fff 0);
+}
+.article a,
+.article h1,
+.article h2 {
+  color: #e84e40;
+}
+.article code {
+  background: #eee;
+}
+.article kbd {
+  color: #555;
+  background-color: #fcfcfc;
+  border: 1px solid #ccc;
+  border-bottom-color: #bbb;
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 #bbb;
+}
+.article h1 {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+.article a {
+  border-bottom: 1px dotted;
+}
+.article a:focus,
+.article a:hover {
+  color: #00bfa5;
+}
+.article .headerlink {
+  color: rgba(0, 0, 0, 0.26);
+  border: none;
+}
+.article table {
+  box-shadow: 0 1.5px 3px rgba(0, 0, 0, 0.24), 0 3px 8px rgba(0, 0, 0, 0.05);
+  border-radius: 3px;
+}
+.article table th {
+  background: #ee7a70;
+  color: #fff;
+}
+.article table td {
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
+}
+.article blockquote {
+  border-left: 2px solid rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+}
+.footer {
+  background: #e84e40;
+  color: #fff;
+}
+.footer a {
+  border: none;
+}
+.copyright {
+  color: rgba(0, 0, 0, 0.54);
+}
+.pagination a .button,
+.pagination a .title {
+  color: #fff;
+}
+.pagination .direction {
+  color: hsla(0, 0%, 100%, 0.7);
+}
+.admonition {
+  background: #29b6f6;
+  color: #fff;
+}
+.admonition pre {
+  background: hsla(0, 0%, 100%, 0.3);
+}
+.admonition.warning {
+  background: #e84e40;
+}
+.admonition a,
+.admonition a:hover {
+  color: #fff;
+}
+.article {
+  font-size: 14px;
+  line-height: 1.7em;
+}
+.article:after {
+  content: ' ';
+  display: block;
+  clear: both;
+}
+.article .wrapper {
+  padding: 80px 16px 92px;
+}
+.ios.standalone .article {
+  position: absolute;
+  top: 56px;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.ios.standalone .article .wrapper {
+  position: relative;
+  min-height: 100%;
+  padding-top: 60px;
+  margin-bottom: 2px;
+}
+.article h1 {
+  font-size: 24px;
+  line-height: 1.333334em;
+  padding: 8px 0 16px;
+}
+.article h2 {
+  font-size: 20px;
+  line-height: 1.4em;
+  padding-top: 92px;
+  margin-top: -56px;
+}
+.ios.standalone .article h2 {
+  padding-top: 36px;
+  margin: 0;
+}
+.article h3,
+.article h4 {
+  font-size: 14px;
+  padding-top: 76px;
+  margin-top: -56px;
+}
+.ios.standalone .article h3,
+.ios.standalone .article h4 {
+  padding-top: 20px;
+  margin-top: 0;
+}
+.article .headerlink {
+  float: right;
+  margin-left: 20px;
+  font-size: 14px;
+}
+h1 .article .headerlink {
+  display: none;
+}
+.article ol,
+.article p,
+.article ul {
+  margin-top: 1.5em;
+}
+.article li,
+.article li ol,
+.article li ul {
+  margin-top: 0.75em;
+}
+.article li {
+  margin-left: 18px;
+}
+.article li p {
+  display: inline;
+}
+.article p > code {
+  white-space: nowrap;
+  padding: 2px 4px;
+}
+.article kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  line-height: 10px;
+}
+.article hr {
+  margin-top: 1.5em;
+}
+.article img {
+  max-width: 100%;
+}
+.article pre {
+  padding: 16px;
+  margin: 1.5em -16px 0;
+  line-height: 1.5em;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.article table {
+  margin: 3em 0 1.5em;
+  font-size: 13px;
+  overflow: hidden;
+}
+.no-js .article table {
+  display: inline-block;
+  max-width: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.article table th {
+  min-width: 100px;
+  font-size: 12px;
+  text-align: left;
+}
+.article table td,
+.article table th {
+  padding: 12px 16px;
+  vertical-align: top;
+}
+.article blockquote {
+  padding-left: 16px;
+}
+.article .data {
+  margin: 1.5em -16px;
+  padding: 1.5em 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  text-align: center;
+}
+.article .data table {
+  display: inline-block;
+  margin: 0 16px;
+  text-align: left;
+}
+.footer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0 4px;
+}
+.copyright {
+  margin: 1.5em 0;
+}
+.pagination {
+  max-width: 1184px;
+  height: 92px;
+  padding: 4px 0;
+  margin-left: auto;
+  margin-right: auto;
+  overflow: hidden;
+}
+.pagination a {
+  display: block;
+  height: 100%;
+}
+.pagination .next,
+.pagination .previous {
+  position: relative;
+  float: left;
+  height: 100%;
+}
+.pagination .previous {
+  width: 25%;
+}
+.pagination .previous .direction,
+.pagination .previous .stretch {
+  display: none;
+}
+.pagination .next {
+  width: 75%;
+  text-align: right;
+}
+.pagination .page {
+  display: table;
+  position: absolute;
+  bottom: 4px;
+}
+.pagination .direction {
+  display: block;
+  position: absolute;
+  bottom: 40px;
+  width: 100%;
+  font-size: 15px;
+  line-height: 20px;
+  padding: 0 52px;
+}
+.pagination .stretch {
+  padding: 0 4px;
+}
+.pagination .stretch .title {
+  font-size: 18px;
+  padding: 11px 0 13px;
+}
+.admonition {
+  margin: 20px -16px 0;
+  padding: 20px 16px;
+}
+.admonition > :first-child {
+  margin-top: 0;
+}
+.admonition .admonition-title {
+  font-size: 20px;
+}
+.admonition .admonition-title:before {
+  content: '\e611';
+  display: block;
+  float: left;
+  font-family: Icon;
+  font-size: 24px;
+  vertical-align: -0.1em;
+  margin-right: 5px;
+}
+.admonition.warning .admonition-title:before {
+  content: '\e610';
+}
+.article h3 {
+  font-weight: 700;
+}
+.article h4 {
+  font-weight: 400;
+  font-style: italic;
+}
+.article h2 a,
+.article h3 a,
+.article h4 a,
+.article h5 a,
+.article h6 a {
+  font-weight: 400;
+  font-style: normal;
+}
+.bar {
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-transition: opacity 0.2s cubic-bezier(0.75, 0, 0.25, 1),
+    -webkit-transform 0.4s cubic-bezier(0.75, 0, 0.25, 1);
+  transition: opacity 0.2s cubic-bezier(0.75, 0, 0.25, 1),
+    -webkit-transform 0.4s cubic-bezier(0.75, 0, 0.25, 1);
+  transition: opacity 0.2s cubic-bezier(0.75, 0, 0.25, 1),
+    transform 0.4s cubic-bezier(0.75, 0, 0.25, 1);
+  transition: opacity 0.2s cubic-bezier(0.75, 0, 0.25, 1),
+    transform 0.4s cubic-bezier(0.75, 0, 0.25, 1),
+    -webkit-transform 0.4s cubic-bezier(0.75, 0, 0.25, 1);
+}
+#toggle-search:checked ~ .header .bar,
+.toggle-search .bar {
+  -webkit-transform: translate3d(0, -56px, 0);
+  transform: translate3d(0, -56px, 0);
+}
+.bar.search .button-reset {
+  -webkit-transform: scale(0.5);
+  transform: scale(0.5);
+  -webkit-transition: opacity 0.4s cubic-bezier(0.1, 0.7, 0.1, 1),
+    -webkit-transform 0.4s cubic-bezier(0.1, 0.7, 0.1, 1);
+  transition: opacity 0.4s cubic-bezier(0.1, 0.7, 0.1, 1),
+    -webkit-transform 0.4s cubic-bezier(0.1, 0.7, 0.1, 1);
+  transition: opacity 0.4s cubic-bezier(0.1, 0.7, 0.1, 1),
+    transform 0.4s cubic-bezier(0.1, 0.7, 0.1, 1);
+  transition: opacity 0.4s cubic-bezier(0.1, 0.7, 0.1, 1),
+    transform 0.4s cubic-bezier(0.1, 0.7, 0.1, 1),
+    -webkit-transform 0.4s cubic-bezier(0.1, 0.7, 0.1, 1);
+  opacity: 0;
+}
+.bar.search.non-empty .button-reset {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  opacity: 1;
+}
+.results {
+  -webkit-transition: opacity 0.3s 0.1s, width 0s 0.4s, height 0s 0.4s;
+  transition: opacity 0.3s 0.1s, width 0s 0.4s, height 0s 0.4s;
+}
+#toggle-search:checked ~ .main .results,
+.toggle-search .results {
+  -webkit-transition: opacity 0.4s, width 0s, height 0s;
+  transition: opacity 0.4s, width 0s, height 0s;
+}
+.results .list a {
+  -webkit-transition: background 0.25s;
+  transition: background 0.25s;
+}
+.no-csstransforms3d .bar.default {
+  display: table;
+}
+.no-csstransforms3d .bar.search {
+  display: none;
+  margin-top: 0;
+}
+.no-csstransforms3d #toggle-search:checked ~ .header .bar.default,
+.no-csstransforms3d .toggle-search .bar.default {
+  display: none;
+}
+.no-csstransforms3d #toggle-search:checked ~ .header .bar.search,
+.no-csstransforms3d .toggle-search .bar.search {
+  display: table;
+}
+.bar.search {
+  opacity: 0;
+}
+.bar.search .query {
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+}
+.bar.search .query::-webkit-input-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+.bar.search .query:-moz-placeholder,
+.bar.search .query::-moz-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+.bar.search .query:-ms-input-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+.bar.search .button .icon:active {
+  background: rgba(0, 0, 0, 0.12);
+}
+.results {
+  box-shadow: 0 4px 7px rgba(0, 0, 0, 0.23), 0 8px 25px rgba(0, 0, 0, 0.05);
+  background: #fff;
+  color: rgba(0, 0, 0, 0.87);
+  opacity: 0;
+}
+#toggle-search:checked ~ .main .results,
+.toggle-search .results {
+  opacity: 1;
+}
+.results .meta {
+  background: #e84e40;
+  color: #fff;
+}
+.results .list a {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+.results .list a:last-child {
+  border-bottom: none;
+}
+.results .list a:active {
+  background: rgba(0, 0, 0, 0.12);
+}
+.result span {
+  color: rgba(0, 0, 0, 0.54);
+}
+#toggle-search:checked ~ .header,
+.toggle-search .header {
+  background: #fff;
+  color: rgba(0, 0, 0, 0.54);
+}
+#toggle-search:checked ~ .header:before,
+.toggle-search .header:before {
+  background: rgba(0, 0, 0, 0.54);
+}
+#toggle-search:checked ~ .header .bar.default,
+.toggle-search .header .bar.default {
+  opacity: 0;
+}
+#toggle-search:checked ~ .header .bar.search,
+.toggle-search .header .bar.search {
+  opacity: 1;
+}
+.bar.search {
+  margin-top: 8px;
+}
+.bar.search .query {
+  font-size: 18px;
+  padding: 13px 0;
+  margin: 0;
+  width: 100%;
+  height: 48px;
+}
+.bar.search .query::-ms-clear {
+  display: none;
+}
+.results {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 100%;
+  z-index: 1;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+}
+.results .scrollable {
+  top: 56px;
+}
+#toggle-search:checked ~ .main .results,
+.toggle-search .results {
+  width: 100%;
+  overflow-y: visible;
+}
+.results .meta {
+  font-weight: 700;
+}
+.results .meta strong {
+  display: block;
+  font-size: 11px;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 16px;
+}
+.results .list a {
+  display: block;
+}
+.result {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 12px 16px 16px;
+}
+.result h1 {
+  line-height: 24px;
+}
+.result h1,
+.result span {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.result span {
+  font-size: 12px;
+}
+.no-csstransforms3d .results {
+  display: none;
+}
+.no-csstransforms3d #toggle-search:checked ~ .main .results,
+.no-csstransforms3d .toggle-search .results {
+  display: block;
+  overflow: auto;
+}
+.meta {
+  text-transform: uppercase;
+  font-weight: 700;
+}
+@media only screen and (min-width: 960px) {
+  .backdrop {
+    background: #f2f2f2;
+  }
+  .backdrop-paper:after {
+    box-shadow: 0 1.5px 3px rgba(0, 0, 0, 0.24), 0 3px 8px rgba(0, 0, 0, 0.05);
+  }
+  .button-menu {
+    display: none;
+  }
+  .drawer {
+    float: left;
+    height: auto;
+    margin-bottom: 96px;
+    padding-top: 80px;
+  }
+  .drawer,
+  .drawer .scrollable {
+    position: static;
+  }
+  .article {
+    margin-left: 262px;
+  }
+  .footer {
+    z-index: 4;
+  }
+  .copyright {
+    margin-bottom: 64px;
+  }
+  .results {
+    height: auto;
+    top: 64px;
+  }
+  .results .scrollable {
+    position: static;
+    max-height: 413px;
+  }
+}
+@media only screen and (max-width: 959px) {
+  #toggle-drawer:checked ~ .overlay,
+  .toggle-drawer .overlay {
+    width: 100%;
+    height: 100%;
+  }
+  .drawer {
+    -webkit-transform: translate3d(-262px, 0, 0);
+    transform: translate3d(-262px, 0, 0);
+    -webkit-transition: -webkit-transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: -webkit-transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      -webkit-transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .no-csstransforms3d .drawer {
+    display: none;
+  }
+  .drawer {
+    background: #fff;
+  }
+  .project {
+    box-shadow: 0 1.5px 3px rgba(0, 0, 0, 0.24), 0 3px 8px rgba(0, 0, 0, 0.05);
+    background: #e84e40;
+    color: #fff;
+  }
+  .drawer {
+    position: fixed;
+    z-index: 4;
+  }
+  #toggle-search:checked ~ .main .results,
+  .drawer,
+  .toggle-search .results {
+    height: 100%;
+  }
+}
+@media only screen and (min-width: 720px) {
+  .header {
+    height: 64px;
+    padding: 8px;
+  }
+  .header .stretch {
+    padding: 0 16px;
+  }
+  .header .stretch .title {
+    font-size: 20px;
+    padding: 12px 0;
+  }
+  .project .name {
+    margin: 26px 0 0 5px;
+  }
+  .article .wrapper {
+    padding: 90px 24px 96px;
+  }
+  .article .data {
+    margin: 1.5em -24px;
+  }
+  .article .data table {
+    margin: 0 24px;
+  }
+  .article h2 {
+    padding-top: 100px;
+    margin-top: -64px;
+  }
+  .ios.standalone .article h2 {
+    padding-top: 28px;
+    margin-top: 8px;
+  }
+  .article h3,
+  .article h4 {
+    padding-top: 84px;
+    margin-top: -64px;
+  }
+  .ios.standalone .article h3,
+  .ios.standalone .article h4 {
+    padding-top: 20px;
+    margin-top: 0;
+  }
+  .article pre {
+    padding: 1.5em 24px;
+    margin: 1.5em -24px 0;
+  }
+  .footer {
+    padding: 0 8px;
+  }
+  .pagination {
+    height: 96px;
+    padding: 8px 0;
+  }
+  .pagination .direction {
+    padding: 0 56px;
+    bottom: 40px;
+  }
+  .pagination .stretch {
+    padding: 0 8px;
+  }
+  .admonition {
+    margin: 20px -24px 0;
+    padding: 20px 24px;
+  }
+  .bar.search .query {
+    font-size: 20px;
+    padding: 12px 0;
+  }
+  .results .scrollable {
+    top: 64px;
+  }
+  .results .meta strong {
+    padding: 16px 24px;
+  }
+  .result {
+    padding: 16px 24px 20px;
+  }
+}
+@media only screen and (min-width: 1200px) {
+  .header {
+    width: 100%;
+  }
+  .drawer .scrollable .wrapper hr {
+    width: 48px;
+  }
+}
+@media only screen and (orientation: portrait) {
+  .ios.standalone .header {
+    height: 76px;
+    padding-top: 24px;
+  }
+  .ios.standalone .header:before {
+    content: ' ';
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 3;
+    width: 100%;
+    height: 20px;
+  }
+  .ios.standalone .drawer .scrollable {
+    top: 124px;
+  }
+  .ios.standalone .project {
+    padding-top: 20px;
+  }
+  .ios.standalone .project:before {
+    content: ' ';
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 3;
+    width: 100%;
+    height: 20px;
+  }
+  .ios.standalone .article {
+    position: absolute;
+    top: 76px;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+  .ios.standalone .results .scrollable {
+    top: 76px;
+  }
+}
+@media only screen and (orientation: portrait) and (min-width: 720px) {
+  .ios.standalone .header {
+    height: 84px;
+    padding-top: 28px;
+  }
+  .ios.standalone .results .scrollable {
+    top: 84px;
+  }
+}
+@media only screen and (max-width: 719px) {
+  .bar .path {
+    display: none;
+  }
+}
+@media only screen and (max-width: 479px) {
+  .button-github,
+  .button-twitter {
+    display: none;
+  }
+}
+@media only screen and (min-width: 720px) and (max-width: 959px) {
+  .header .stretch {
+    padding: 0 24px;
+  }
+}
+@media only screen and (min-width: 480px) {
+  .pagination .next,
+  .pagination .previous {
+    width: 50%;
+  }
+  .pagination .previous .direction {
+    display: block;
+  }
+  .pagination .previous .stretch {
+    display: table;
+  }
+}
+@media print {
+  .drawer,
+  .footer,
+  .header,
+  .headerlink {
+    display: none;
+  }
+  .article .wrapper {
+    padding-top: 0;
+  }
+  .article pre,
+  .article pre * {
+    color: rgba(0, 0, 0, 0.87) !important;
+  }
+  .article pre {
+    border: 1px solid rgba(0, 0, 0, 0.12);
+  }
+  .article table {
+    border-radius: none;
+    box-shadow: none;
+  }
+  .article table th {
+    color: #e84e40;
+  }
+}


### PR DESCRIPTION
Gives the user the ability to provide a list_item parameter within the config.toml file to customize the icon preceding each list item within the site.


The current version of the theme is using FontAwesome to provide icons as the list item bullets. 

This PR removes the CSS code applying the FontAwesome code and instead styles the `<li>` elements using the `list_item` param within the config.toml that is expected within the blog repo's.

If this is the behavior you like, I can go a bit deeper into the code and remove any FontAwesome packages and CSS that may be left over.